### PR TITLE
Manual cron install for Acmetool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV RANCHER_GEN_RELEASE=v0.5.0 \
     RGON_EXEC_RELEASE=v1.1.1 \
     ACMETOOL_RELEASE=v0.0.59
 
+# Consider revising: https://www.ctl.io/developers/blog/post/dockerfile-add-vs-copy/#which-to-use
 ADD https://github.com/causticlab/go-rancher-gen/releases/download/${RANCHER_GEN_RELEASE}/rancher-gen-linux-amd64.tar.gz /tmp/rancher-gen.tar.gz
 ADD https://github.com/causticlab/rgon-exec/releases/download/${RGON_EXEC_RELEASE}/rgon-exec-linux-amd64.tar.gz /tmp/rgon-exec.tar.gz
 ADD https://github.com/hlandau/acme/releases/download/${ACMETOOL_RELEASE}/acmetool-${ACMETOOL_RELEASE}-linux_amd64.tar.gz /tmp/acmetool.tar.gz
@@ -15,9 +16,8 @@ RUN ls /tmp/*.tar.gz | xargs -i tar zxf {} -C /usr/local/bin
 RUN mv /usr/local/bin/acmetool-${ACMETOOL_RELEASE}-linux_amd64/bin/acmetool /usr/local/bin/acmetool \
  && mv /usr/local/bin/rgon-exec-linux-amd64 /usr/local/bin/rgon-exec
 
-#ADD ./examples/rancher-gen/rancher-gen.cfg ./examples/rancher-gen/rancher-gen-firstrun.cfg ./examples/rancher-gen/nginx.tmpl /etc/rancher-gen/default/
-#ADD ./examples/acmetool/responses ./examples/acmetool/target /var/lib/acme/conf/
-ADD  app/acmetool/hooks/01copyCertsToNginx.sh  /usr/lib/acme/hooks/
+COPY app/acmetool/hooks/01copyCertsToNginx.sh  /usr/lib/acme/hooks/
+COPY app/cron/daily/acmetool-cron /etc/periodic/daily/
 COPY examples/rancher-gen/ /app/rancher-gen/default/
 COPY examples/acmetool/ /var/lib/acme/conf/
 COPY app/entrypoint.sh /app/

--- a/app/cron/daily/acmetool-cron
+++ b/app/cron/daily/acmetool-cron
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/local/bin/acmetool --batch

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -15,6 +15,10 @@ if [[ -z "$CATTLE_SECRET_KEY" ]]; then
     exit 1
 fi
 
+function acmetool_init {
+  /usr/local/bin/acmetool quickstart
+}
+
 function copy_config_files {
     if [[ ! -d /etc/rancher-gen/default ]]; then
         mkdir -p /etc/rancher-gen/default
@@ -65,6 +69,7 @@ check_writable_directory '/etc/nginx/certs'
 check_writable_directory '/etc/nginx/vhost.d'
 check_dh_group
 check_nginx_conf
+acmetool_init
 rancher_gen_firstrun
 
 exec "$@"

--- a/examples/acmetool/responses
+++ b/examples/acmetool/responses
@@ -12,4 +12,4 @@
 "acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf": true
 "acmetool-quickstart-choose-server": https://acme-staging.api.letsencrypt.org/directory
 "acmetool-quickstart-choose-method": proxy
-"acmetool-quickstart-install-cronjob": true
+"acmetool-quickstart-install-cronjob": false


### PR DESCRIPTION
Manually installs cron for Acmetool. Also introduces `acmetool quickstart` during entrypoint.

Resolves https://github.com/CausticLab/rgon-proxy/issues/4