### PR TITLE
Add ability to swap Acmetool vars with ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,4 @@ RUN chmod +x /usr/local/bin/rancher-gen \
     && rm /tmp/*.tar.gz
 
 ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh" ]
-#CMD /usr/local/bin/rancher-gen --config /etc/rancher-gen/default/rancher-gen.cfg
 CMD ["rancher-gen", "--config", "/etc/rancher-gen/default/rancher-gen.cfg"]

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -16,7 +16,19 @@ if [[ -z "$CATTLE_SECRET_KEY" ]]; then
 fi
 
 function acmetool_init {
-  /usr/local/bin/acmetool quickstart
+    if [[ -z "$ACME_EMAIL" ]]; then
+        echo "Warning: can't get my ACME_EMAIL !" >&2
+    else
+        sed -i "s/hostmaster@example.com/$ACME_EMAIL/g" /var/lib/acme/conf/responses
+    fi
+
+    if [[ -z "$ACME_API" ]]; then
+        echo "Warning: can't get my ACME_API !" >&2
+    else
+        sed -i "s/https:\/\/acme-staging.api.letsencrypt.org\/directory/$ACME_API/g" /var/lib/acme/conf/responses
+    fi
+
+    /usr/local/bin/acmetool quickstart
 }
 
 function copy_config_files {


### PR DESCRIPTION
Replaces default parameters in `/var/lib/acme/conf/responses` with contents of `ACME_EMAIL` and `ACME_API` environment variables.

Requires https://github.com/CausticLab/rancher-catalog/pull/1 

Resolves Resolves https://github.com/CausticLab/rgon-proxy/issues/3