### PR TITLE
Added the possibility to enable the stats page

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ rgon.stats=1.1.1.1
 rgon.stats=1.1.1.1,2.2.2.2
 rgon.stats=all
 ```
+Use `http://server-ip/nginx_status` to access these stats - note it only work with the ip-address were the nginx is running on
+
 
 ## Upcoming Features
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Add labels to containers to indicate domain name and port (if non-80):
 - `rgon.port=80`
 - `rgon.ssl='true'`
 - `rgon.redirect=https`
+- `rgon.stats=1.1.1.1`
 
 ## Update Notice
 RGON-Proxy is currently in an development/alpha state cause of this it might be possible that default config files will change rapidly - To provide always an latest use of those config files please rename the config folder on your server before the update an merge changes by hand. We are currently on an discussion how to solve this problem in the future
@@ -25,7 +26,7 @@ If the `rgon.redirect` label is defined with `https` rgon automatically redirect
 On each start we check if there is allready an key present and if not we generate one.
 
 ### Multiple Domain support
-It is possible to define multiple domains in the `rgon.domain` label seperated by an `,`. 
+It is possible to define multiple domains in the `rgon.domain` label seperated by an `,`.
 If the `rgon.ssl` label is also present we generate an SNI Certificate for all this domains.
 
 ### Custom/Default nginx vhost & location config
@@ -36,9 +37,52 @@ Or define an configuration for each domain with `%domain%[_location]`. Please no
 Add an file with the domain name of the `rgon.domain` label under %YourPath%/htpasswd and your site is protected with an Basic Auth dialog.
 
 ### [Experimental] Vertical scalability
-We wher able to run an nginx instance on each host using the scheduler commands of rancher but it is currently only possible for simple http requests
-cause we need an centralized secure store for certificates before we can continiue this feature.
+We were able to run an nginx instance on each host using the scheduler commands of rancher but it is currently only possible for simple http requests because we need a centralized secure store for certificates before we can continiue this feature.
 
+## Usage
+
+Rancher Labels can be used to specify various modes of operation.
+
+### Label: `rgon.domain`
+
+One or many domains can be defined and comma-separated.
+
+**Domain Label Examples:**
+
+```
+rgon.domain=my-domain.com
+rgon.domain=sub1.my-domain.com,sub2.my-domain.com
+```
+
+### Label: `rgon.redirect`
+
+Optional redirect to the HTTPS port. Only valid when label value equals `https`, is ignored otherwise.
+
+**Redirect Label Examples:**
+
+```sh
+# Does nothing, leaves traffic routed to rgon.port label
+rgon.redirect=
+
+# Same as empty value
+rgon.redirect=http
+
+# Reroute traffic to :443
+rgon.redirect=https
+
+```
+
+### Label: `rgon.stats`
+
+The [Nginx Status module](https://nginx.org/en/docs/http/ngx_http_stub_status_module.html) can be enabled by adding a `rgon.stats` label. This label must specify the IP address of machines that are allowed to read these stats, or `all` for open access. Multiple IP addresses can be comma-separated.
+
+**Status Label Examples:**
+
+```
+rgon.stats=1.1.1.1
+rgon.stats=1.1.1.1,2.2.2.2
+rgon.stats=all
+```
 
 ## Upcoming Features
 

--- a/examples/rancher-gen/nginx.tmpl
+++ b/examples/rancher-gen/nginx.tmpl
@@ -51,7 +51,22 @@ server {
   server_name _; # This is just an invalid value which will never trigger on a real hostname.
   listen 80;
   access_log /var/log/nginx/access.log vhost;
-  return 503;
+
+  {{ if service.Labels.Exists "rgon.stats" }}
+  location /nginx_status {
+    stub_status on;
+    {{- $statips := (split (replace (service.Labels.GetValue "rgon.stats") " " "" -1) ",") -}}
+    {{ range $ip := $statips }}
+    allow {{$ip}};
+    {{- end }}
+    deny all;
+  }
+  {{end}}
+
+      
+  location / {
+    return 503;
+  }   
 }
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}


### PR DESCRIPTION
fixed #35 
i implemented the nginx_stats directive.
To enable it upgrade your rgon service and on the rgon-proxy sidekick add the label `rgon.stats` with an IP or `all` to restrict the access.
It is also possible to define multiple ips seperated with an `,`