### PR TITLE
Fix/hosts upstream grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Add labels to containers to indicate domain name and port (if non-80):
 - `rgon.ssl='true'`
 - `rgon.redirect=https`
 - `rgon.stats=1.1.1.1`
+- `rgon.weight=1`
+- `rgon.backup=backup`
 
 ## Update Notice
 RGON-Proxy is currently in an development/alpha state cause of this it might be possible that default config files will change rapidly - To provide always an latest use of those config files please rename the config folder on your server before the update an merge changes by hand. We are currently on an discussion how to solve this problem in the future
@@ -85,6 +87,32 @@ rgon.stats=all
 ```
 Use `http://server-ip/nginx_status` to access these stats - note it only work with the ip-address were the nginx is running on
 
+
+### Label: `rgon.weight`
+
+Optional [Nginx weight parameter](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#weight) determines the order of load balancing. Defaults to `1` and can be overridden with this label.
+
+**Weight Label Examples:**
+
+```
+rgon.weight=
+rgon.weight=0
+rgon.weight=2
+```
+
+### Label: `rgon.backup`
+
+Optional [Nginx backup parameter](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#backup) specifies servers to use only in the case that the main upstream servers are down. Defaults to `""` and can be overridden with this label.
+
+**Weight Label Examples:**
+
+```go
+# Empty string, normal operation
+rgon.backup=
+
+# Specifies backup
+rgon.backup=backup
+```
 
 ## Upcoming Features
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ rgon.weight=2
 
 Optional [Nginx backup parameter](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#backup) specifies servers to use only in the case that the main upstream servers are down. Defaults to `""` and can be overridden with this label.
 
-**Weight Label Examples:**
+**Backup Label Examples:**
 
 ```go
 # Empty string, normal operation

--- a/examples/rancher-gen/nginx.tmpl
+++ b/examples/rancher-gen/nginx.tmpl
@@ -52,7 +52,7 @@ server {
   listen 80;
   access_log /var/log/nginx/access.log vhost;
 
-  {{ if service.Labels.Exists "rgon.stats" }}
+  {{- if service.Labels.Exists "rgon.stats" }}
   location /nginx_status {
     stub_status on;
     {{- $statips := (split (replace (service.Labels.GetValue "rgon.stats") " " "" -1) ",") -}}
@@ -61,12 +61,11 @@ server {
     {{- end }}
     deny all;
   }
-  {{end}}
+  {{ end }}
 
-      
   location / {
     return 503;
-  }   
+  }
 }
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
@@ -89,27 +88,25 @@ server {
 ## TEMPLATES -------
 {{- define "upstream"}}
   {{- $serv := .}}
-  {{range $cnt := .Containers -}}
-    {{- $defaultPort := "80"}}
-    {{- $port := where $serv.Ports "InternalPort" $defaultPort }}
-    {{- if .Labels.Exists "rgon.port" }}
-      # Has rgon.port label
-      server {{$cnt.Address}}:{{$cnt.Labels.GetValue "rgon.port"}};
-    {{- else }}
-      # No rgon.port label
-      {{- $portLen := len $serv.Ports -}}
-      {{- if eq $portLen 0 }}
-      # No ports available
-      server {{$cnt.Address}} down;
-      {{- else }}
-      # Ports available
-        {{- range $p := $serv.Ports }}
-        server {{$cnt.Address}}:{{ $p.InternalPort }};
-        {{ end -}}
-      {{ end -}}
-    {{ end -}}
-  {{- end}}
-{{- end}}
+  {{- range $cnt := .Containers -}}
+    {{- $weight := $cnt.Labels.GetValue "rgon.weight" "1" }}
+    {{- $backup := $cnt.Labels.GetValue "rgon.backup" "" }}
+    {{- $portLen := len $serv.Ports }}
+    {{- $portInt := where $serv.Ports "InternalPort" "80" }}
+    {{- $portLabel := $cnt.Labels.GetValue "rgon.port" "" -}}
+
+    {{- if eq $cnt.State "stopped" }}{{ printf "\n  server %s down; # Container stopped" $cnt.Address }}
+    {{- else if (and (eq $portLen 0) (eq (len $portInt) 0 )) }}{{- printf "\n  server %s down; # No ports available" $cnt.Address -}}{{ end -}}
+
+    {{- if (and (gt $portLen 0) (ne $portLabel "") (ne $cnt.State "stopped") ) }}
+    {{- printf "\n  server %s:%s weight=%s %s; # Has rgon.port label" $cnt.Address $portLabel $weight $backup }}
+    {{- end -}}
+
+    {{- if (and (or (gt $portLen 0) (gt (len $portInt) 0) ) (ne $cnt.State "stopped") (eq $portLabel "")  ) }}{{ range $p := $serv.Ports }}
+    {{- printf "\n  server %s:%s weight=%s %s; # No rgon.port label, ports available" $cnt.Address $p.InternalPort $weight $backup }}
+    {{- end }}{{ end -}}
+  {{- end -}}
+{{- end }}
 
 {{- define "upstreamHost"}}
   {{ $port := .Labels.GetValue "rgon.port" "8080" -}}
@@ -191,7 +188,7 @@ server {
     break;
   }
 
-  {{- template "locationBlock" (dict "domain" $domain)}}
+  {{ template "locationBlock" (dict "domain" $domain)}}
 {{- end}}
 
 
@@ -236,13 +233,20 @@ server {
 {{range $opt, $services := services | groupByLabel "rgon.domain" -}}
 {{- $domains := (split (replace $opt " " "" -1) ",") -}}
 {{- $domain := index $domains 0 -}}
-{{range $serv := $services -}}
+{{- $serv := index $services 0 }}
+
 {{- $redirect_target := ($serv.Labels.GetValue "rgon.redirect" "http") -}}
 {{- $has_certs := ( and (exists (printf "/etc/nginx/certs/%s/fullchain" $domain)) (exists (printf "/etc/nginx/certs/%s/privkey" $domain)) ) -}}
 {{- $should_redirect := (and (eq $redirect_target "https") ($has_certs)) -}}
 
+{{- if (exists (printf "/etc/nginx/vhost.d/%s_upstream" $domain)) }}
+  include {{ printf "/etc/nginx/vhost.d/%s_upstream" $domain}};
+{{- end }}
+
 upstream {{$domain}} {
+{{ range $serv := $services }}
   {{- template "upstream" $serv}}
+{{ end }}
 }
 
 server {
@@ -254,5 +258,4 @@ server {
   {{- template "httpsServer" (dict "domains" $domains "redirect_target" $redirect_target) }}
 }
 {{ end }}{{/* ssl block */}}
-{{ end }}{{/* range $serv */}}
 {{ end }}{{/* range $services */}}

--- a/examples/rancher-gen/nginx.tmpl
+++ b/examples/rancher-gen/nginx.tmpl
@@ -112,7 +112,11 @@ server {
 {{- end}}
 
 {{- define "upstreamHost"}}
-  server {{.Address}}:{{.Labels.GetValue "rgon.port" "8080"}};
+  {{ $port := .Labels.GetValue "rgon.port" "8080" -}}
+  {{ $weight := .Labels.GetValue "rgon.weight" "1" -}}
+  {{ $backup := .Labels.GetValue "rgon.backup" "" -}}
+
+  {{ printf "server %s:%s weight=%s %s;" .Address $port $weight $backup }}
 {{- end}}
 
 {{- define "locationBlock"}}
@@ -204,13 +208,16 @@ upstream acmetool {
 {{range $opt, $hosts := hosts | groupByLabel "rgon.domain" -}}
 {{- $domains := (split (replace $opt " " "" -1) ",") -}}
 {{- $domain := index $domains 0 -}}
-{{range $host := $hosts}}
+{{ $host := index $hosts 0 }}
+
 {{- $redirect_target := ($host.Labels.GetValue "rgon.redirect" "http") -}}
 {{- $has_certs := ( and (exists (printf "/etc/nginx/certs/%s/fullchain" $domain)) (exists (printf "/etc/nginx/certs/%s/privkey" $domain)) ) -}}
 {{- $should_redirect := (and (eq $redirect_target "https") ($has_certs)) -}}
 
 upstream {{$domain}}{
-  {{- template "upstreamHost" $host}}
+{{range $host := $hosts}}
+  {{- template "upstreamHost" $host -}}
+{{ end }}
 }
 
 server {
@@ -222,7 +229,6 @@ server {
   {{- template "httpsServer" (dict "domains" $domains "redirect_target" $redirect_target) }}
 }
 {{ end }}{{/* ssl block */}}
-{{ end }}{{/* range $host */}}
 {{ end }}{{/* range $hosts */}}
 
 


### PR DESCRIPTION
Updates host and service iterators: fixes duplicate upstream directives, adds weight and backup labels.

Attempted to make the upstream template logic a bit clearer, discovered a nicer formatting pattern in the process:

```go
{{- if eq $cnt.State "stopped" }}{{ printf "\n  server %s down; # Container stopped" $cnt.Address }}
```

Using `printf "\n ... "` places newlines in the correct spot, allows for more uniform indenting, and negates the hassle of worrying about where to put `{{-` and `-}}`.



Provides features for https://github.com/CausticLab/rgon-proxy/issues/41

Resolves https://github.com/CausticLab/rgon-proxy/issues/49 and https://github.com/CausticLab/rgon-proxy/issues/48